### PR TITLE
fix: update git repo url for git lfs clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ This all happens in the blink of an eye.
 Clone this repo and its submodules and download all LFS objects:
 
 ```sh
-git lfs clone --recurse-submodules https://github.com/doramatadora/edgeml-recommender.git
+git lfs clone --recurse-submodules https://github.com/fastly/edgeml-recommender.git
 ```
 
 This includes the `MetObjects.csv` dataset from [`metmuseum/openaccess`](https://github.com/metmuseum/openaccess).


### PR DESCRIPTION
I just noticed the specified git repo url doesn't work as is. This PR addresses this issue.